### PR TITLE
fix: checkboxes replace the decorators on test type page

### DIFF
--- a/src/components/testtype.jsx
+++ b/src/components/testtype.jsx
@@ -13,48 +13,23 @@ export default function TestType() {
         What LETF tests do you need to run?
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-        <div className="flex items-center space-x-4">
-          <label className="flex items-center space-x-2">
+        <div className="flex items-center space-x-3">
+          <label className="flex items-center space-x-4">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Vibration</span>
+          </label>          
+        </div>
+        <div className="flex items-center space-x-3">
+          <label className="flex items-center space-x-4">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">LO2</span>
           </label>
-          
         </div>
         <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">LO2</span>
-        </div>
-        <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">Load test</span>
+          <label className="flex items-center space-x-4">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Load Test</span>
+          </label> 
         </div>
         <div className="flex items-center space-x-3">
           <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">

--- a/src/components/testtype.jsx
+++ b/src/components/testtype.jsx
@@ -44,68 +44,28 @@ export default function TestType() {
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-        <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-4">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Pressure Test</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">
-            Temperature test
-          </span>
+          <label className="flex items-center space-x-4">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Temperature Test</span>
+          </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">
-            Combustion test
-          </span>
+          <label className="flex items-center space-x-4">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Combustion Test</span>
+          </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">Cryo</span>
+          <label className="flex items-center space-x-4">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Cryo</span>
+          </label> 
         </div>
       </div>
       <div className="flex justify-end">

--- a/src/components/testtype.jsx
+++ b/src/components/testtype.jsx
@@ -14,55 +14,55 @@ export default function TestType() {
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         <div className="flex items-center space-x-3">
-          <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Vibration</span>
           </label>          
         </div>
         <div className="flex items-center space-x-3">
-          <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">LO2</span>
           </label>
         </div>
         <div className="flex items-center space-x-3">
-          <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Load Test</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Pull Test</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-        <label className="flex items-center space-x-4">
-          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+        <label className="flex items-center space-x-3">
+          <input type="checkbox" name="Checkbox" value="1" class="w-5 h-5 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Payload Transporter</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Pressure Test</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Temperature Test</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Combustion Test</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <label className="flex items-center space-x-4">
+          <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
             <span className="text-gray-700 dark:text-gray-300">Cryo</span>
           </label> 

--- a/src/components/testtype.jsx
+++ b/src/components/testtype.jsx
@@ -46,7 +46,7 @@ export default function TestType() {
         <div className="flex items-center space-x-3">
           <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
-            <span className="text-gray-700 dark:text-gray-300">Pressure Test</span>
+            <span className="text-gray-700 dark:text-gray-300">Cryo</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">
@@ -64,7 +64,7 @@ export default function TestType() {
         <div className="flex items-center space-x-3">
           <label className="flex items-center space-x-3">
           <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
-            <span className="text-gray-700 dark:text-gray-300">Cryo</span>
+            <span className="text-gray-700 dark:text-gray-300">Pressure Test</span>
           </label> 
         </div>
       </div>

--- a/src/components/testtype.jsx
+++ b/src/components/testtype.jsx
@@ -13,23 +13,12 @@ export default function TestType() {
         What LETF tests do you need to run?
       </h2>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-        <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">Vibration</span>
+        <div className="flex items-center space-x-4">
+          <label className="flex items-center space-x-2">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Vibration</span>
+          </label>
+          
         </div>
         <div className="flex items-center space-x-3">
           <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">

--- a/src/components/testtype.jsx
+++ b/src/components/testtype.jsx
@@ -39,8 +39,8 @@ export default function TestType() {
         </div>
         <div className="flex items-center space-x-3">
         <label className="flex items-center space-x-3">
-          <input type="checkbox" name="Checkbox" value="1" class="w-5 h-5 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
-            <span className="text-gray-700 dark:text-gray-300">Payload Transporter</span>
+          <input type="checkbox" name="Checkbox" value="1" class="w-6 h-6 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Non-Destructive Testing</span>
           </label> 
         </div>
         <div className="flex items-center space-x-3">

--- a/src/components/testtype.jsx
+++ b/src/components/testtype.jsx
@@ -32,62 +32,22 @@ export default function TestType() {
           </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">Pull test</span>
+          <label className="flex items-center space-x-4">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Pull Test</span>
+          </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">
-            Payload Transporter
-          </span>
+        <label className="flex items-center space-x-4">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Payload Transporter</span>
+          </label> 
         </div>
         <div className="flex items-center space-x-3">
-          <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-checked:opacity-100 transition-opacity duration-200">
-              <svg
-                className="w-3 h-3 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="3"
-                viewBox="0 0 24 24"
-              >
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-gray-700 dark:text-gray-300">
-            Pressure test
-          </span>
+        <label className="flex items-center space-x-4">
+          <input type="checkbox" name="Checkbox" value="1" class="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"/>
+            <span className="text-gray-700 dark:text-gray-300">Pressure Test</span>
+          </label> 
         </div>
         <div className="flex items-center space-x-3">
           <div className="relative w-5 h-5 rounded-md bg-gray-200 dark:bg-gray-800 group-hover:bg-gray-300 dark:group-hover:bg-gray-700 transition-colors duration-200 cursor-pointer">


### PR DESCRIPTION
1. This PR is for adding in simple checkboxes for the Test Types. This fix replaces the decorators that were originally present with styled checkboxes.

![Screenshot 2024-05-19 at 11 37 24 AM](https://github.com/AGI-CEO/team-kilo/assets/63355222/c88e3070-7925-4504-81c4-bcb8ad0fb746)

![Screenshot 2024-05-19 at 11 38 46 AM](https://github.com/AGI-CEO/team-kilo/assets/63355222/3793a7c6-74fc-4e06-a6e7-a020d4d091ce)
