### PR TITLE
Added fake gravatar icon to dashboard

### DIFF
--- a/src/components/dash.jsx
+++ b/src/components/dash.jsx
@@ -52,7 +52,7 @@ export default function Dash() {
               alt="Avatar"
               className="rounded-full border"
               height="32"
-              src="/placeholder.svg"
+              src="https://www.gravatar.com/avatar/2c7d99fe281ecd3bcd65ab915bac6dd5?s=250"
               style={{
                 aspectRatio: "32/32",
                 objectFit: "cover",


### PR DESCRIPTION
Changed the ghost icon in dashboard to a fake gravatar. This links to: https://www.gravatar.com/avatar/2c7d99fe281ecd3bcd65ab915bac6dd5?s=250"

Here is the image below for the icon. It is not clickable at this point, but gives appearance of someone logged in:

![Screenshot 2024-05-19 at 12 59 00 PM](https://github.com/AGI-CEO/team-kilo/assets/63355222/4a73752c-5a6c-4eba-bb3a-7070bf6987f6)
